### PR TITLE
Require Travis CI build to use VM infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 
-sudo: false
+sudo: required
 
 matrix:
     fast_finish: true


### PR DESCRIPTION
Per Travis CI, all builds will be migrating away from the container
based infrastructure.